### PR TITLE
Reorder abilist to prioritize 64-bit ABIs

### DIFF
--- a/arm_translation/houdini/houdini-chromeos_brya-patched/houdini-chromeos_brya-patched-38795/prop.json
+++ b/arm_translation/houdini/houdini-chromeos_brya-patched/houdini-chromeos_brya-patched-38795/prop.json
@@ -1,5 +1,5 @@
 {
-    "ro.product.cpu.abilist": "x86_64,x86,arm64-v8a,armeabi-v7a,armeabi",
+    "ro.product.cpu.abilist": "x86_64,arm64-v8a,x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist32": "x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist64": "x86_64,arm64-v8a",
     "ro.dalvik.vm.native.bridge": "libhoudini.so",

--- a/arm_translation/houdini/houdini-chromeos_brya/houdini-chromeos_brya-38795/prop.json
+++ b/arm_translation/houdini/houdini-chromeos_brya/houdini-chromeos_brya-38795/prop.json
@@ -1,5 +1,5 @@
 {
-    "ro.product.cpu.abilist": "x86_64,x86,arm64-v8a,armeabi-v7a,armeabi",
+    "ro.product.cpu.abilist": "x86_64,arm64-v8a,x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist32": "x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist64": "x86_64,arm64-v8a",
     "ro.dalvik.vm.native.bridge": "libhoudini.so",

--- a/arm_translation/houdini/houdini-chromeos_octopus/houdini-chromeos_octopus-39489/prop.json
+++ b/arm_translation/houdini/houdini-chromeos_octopus/houdini-chromeos_octopus-39489/prop.json
@@ -1,5 +1,5 @@
 {
-    "ro.product.cpu.abilist": "x86_64,x86,arm64-v8a,armeabi-v7a,armeabi",
+    "ro.product.cpu.abilist": "x86_64,arm64-v8a,x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist32": "x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist64": "x86_64,arm64-v8a",
     "ro.dalvik.vm.native.bridge": "libhoudini.so",

--- a/arm_translation/houdini/houdini-wsa11-patched/houdini-wsa11-patched-38765/prop.json
+++ b/arm_translation/houdini/houdini-wsa11-patched/houdini-wsa11-patched-38765/prop.json
@@ -1,5 +1,5 @@
 {
-    "ro.product.cpu.abilist":"x86_64,x86,arm64-v8a,armeabi-v7a,armeabi",
+    "ro.product.cpu.abilist":"x86_64,arm64-v8a,x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist32":"x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist64":"x86_64,arm64-v8a",
     "ro.dalvik.vm.native.bridge":"libhoudini.so",

--- a/arm_translation/houdini/houdini-wsa11/houdini-wsa11-38765/prop.json
+++ b/arm_translation/houdini/houdini-wsa11/houdini-wsa11-38765/prop.json
@@ -1,5 +1,5 @@
 {
-    "ro.product.cpu.abilist":"x86_64,x86,arm64-v8a,armeabi-v7a,armeabi",
+    "ro.product.cpu.abilist":"x86_64,arm64-v8a,x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist32":"x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist64":"x86_64,arm64-v8a",
     "ro.dalvik.vm.native.bridge":"libhoudini.so",

--- a/arm_translation/ndk_translation/ndk_translation-chromeos_guybrush-patched/ndk_translation-chromeos_guybrush-patched-R119-15633.69.0/prop.json
+++ b/arm_translation/ndk_translation/ndk_translation-chromeos_guybrush-patched/ndk_translation-chromeos_guybrush-patched-R119-15633.69.0/prop.json
@@ -1,5 +1,5 @@
 {
-    "ro.product.cpu.abilist":"x86_64,x86,armeabi-v7a,armeabi,arm64-v8a",
+    "ro.product.cpu.abilist":"x86_64,arm64-v8a,x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist32":"x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist64":"x86_64,arm64-v8a",
     "ro.dalvik.vm.native.bridge":"libndk_translation.so",

--- a/arm_translation/ndk_translation/ndk_translation-chromeos_guybrush/ndk_translation-chromeos_guybrush-R119-15633.69.0/prop.json
+++ b/arm_translation/ndk_translation/ndk_translation-chromeos_guybrush/ndk_translation-chromeos_guybrush-R119-15633.69.0/prop.json
@@ -1,5 +1,5 @@
 {
-    "ro.product.cpu.abilist":"x86_64,x86,armeabi-v7a,armeabi,arm64-v8a",
+    "ro.product.cpu.abilist":"x86_64,arm64-v8a,x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist32":"x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist64":"x86_64,arm64-v8a",
     "ro.dalvik.vm.native.bridge":"libndk_translation.so",

--- a/arm_translation/ndk_translation/ndk_translation-chromeos_zork/ndk_translation-chromeos_zork-R125-15853.53.0/prop.json
+++ b/arm_translation/ndk_translation/ndk_translation-chromeos_zork/ndk_translation-chromeos_zork-R125-15853.53.0/prop.json
@@ -1,5 +1,5 @@
 {
-    "ro.product.cpu.abilist":"x86_64,x86,armeabi-v7a,armeabi,arm64-v8a",
+    "ro.product.cpu.abilist":"x86_64,arm64-v8a,x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist32":"x86,armeabi-v7a,armeabi",
     "ro.product.cpu.abilist64":"x86_64,arm64-v8a",
     "ro.dalvik.vm.native.bridge":"libndk_translation.so",


### PR DESCRIPTION
Hello,

Like the ndk update, this PR follow the change made on their script to [prioritize 64 bit ABIs to execute a program](https://github.com/casualsnek/waydroid_script/commit/5527d390ebf313f10c2600635708d21846620ac3).

Don't hesitate to close this, if you believe it's unnecessary.
